### PR TITLE
chore(graylog): remove default bool vals from vector psp

### DIFF
--- a/graylog/psp.yaml
+++ b/graylog/psp.yaml
@@ -6,12 +6,8 @@ metadata:
   namespace: graylog
 spec:
   privileged: true
-  hostNetwork: false
-  hostPorts: []
   allowPrivilegeEscalation: true
   defaultAllowPrivilegeEscalation: false
-  hostPID: false
-  hostIPC: false
   runAsUser:
     rule: RunAsAny
   fsGroup:


### PR DESCRIPTION
Remove default values from vector PodSecurityPolicy manifest because ArgoCD permanently see it as out of sync.