### PR TITLE
chore(moodle-vlabx-bkp): unlink moodle vlabx bkp

### DIFF
--- a/projects/kustomization.yaml
+++ b/projects/kustomization.yaml
@@ -22,7 +22,7 @@ resources:
   # - openuchile/metrics.yaml
   - redfid/edx-redfid.yaml
   - edx-virtuallabx/virtuallabx.yaml
-  - ./moodle-virtuallabx/moodle-backup.yaml
+  # - ./moodle-virtuallabx/moodle-backup.yaml
   - ./moodle-virtuallabx/moodle-virtuallabx.yaml
   - test-host-eol/project.yaml
   - emi-project/project.yaml


### PR DESCRIPTION
- Remove the cronjob to backup virtual-labx moodle from openuchile cluster.
- Preserves configuration files.