### PR TITLE
chore(moodle-vlabx): remove all resources & put both svcs in maintenance

### DIFF
--- a/moodle-virtuallabx/ingress.yaml
+++ b/moodle-virtuallabx/ingress.yaml
@@ -22,7 +22,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: moodle
+                name: not-available-nginx-svc
                 port:
                   number: 80
 ---
@@ -49,6 +49,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: moodle-dev
+                name: not-available-nginx-svc
                 port:
                   number: 80

--- a/moodle-virtuallabx/kustomization.yaml
+++ b/moodle-virtuallabx/kustomization.yaml
@@ -2,16 +2,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./moodle-dev.yaml
-  - ./postgres-dev.yaml
-  - ./moodle.yaml
-  - ./postgres.yaml
-  - ./redis.yaml
+  # - ./moodle-dev.yaml
+  # - ./postgres-dev.yaml
+  # - ./moodle.yaml
+  # - ./postgres.yaml
+  # - ./redis.yaml
   - ./ingress.yaml
-  - ./volumes.yaml
-  # - ./unavailable.yaml
-  - ./secrets/moodle-dev-config.yaml
-  - ./secrets/moodle-config.yaml
-  - ./secrets/postgres.yaml
-  - ./secrets/redis.yaml
+  # - ./volumes.yaml
+  - ./unavailable.yaml
+  # - ./secrets/moodle-dev-config.yaml
+  # - ./secrets/moodle-config.yaml
+  # - ./secrets/postgres.yaml
+  # - ./secrets/redis.yaml
 namespace: moodle-ing

--- a/moodle-virtuallabx/unavailable.yaml
+++ b/moodle-virtuallabx/unavailable.yaml
@@ -29,6 +29,6 @@ spec:
     spec:
       containers:
         - name: not-available-eol
-          image: ghcr.io/eol-uchile/not-available-container:virtuallabx-625cccc7bc886c88df466e84e830d6115d4b6dde
+          image: ghcr.io/eol-uchile/not-available-container:virtuallabx-5d2e006f1a251e0c874ae1772b36c4cf626273db
           ports:
             - containerPort: 80


### PR DESCRIPTION
- Delete all resources from the project w/o delete manifests.
- Enable the unavailable service.
- Point both ingresses to the unavailable service.

PD: both volumes are with Retain policy, so deleting its claims won't delete the PVs.